### PR TITLE
Removed node_modules and added .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+.env
+dist/
+build/


### PR DESCRIPTION
After the previous commit made to main, hundreds of node modules were pushed to the codebase from another contributors code. In order to prevent this, users should branch off and commit changes to their branch, rather than to the main or master. To fix this, I created a git ignore file that will allow git to not track or ignore those files if altered on any contributors local so that this doesn't happen again.