### PR TITLE
Added modal to handle edit and add on submit, and delete

### DIFF
--- a/IslandOpsDirectory/client/package-lock.json
+++ b/IslandOpsDirectory/client/package-lock.json
@@ -12,6 +12,7 @@
         "react": "^18.2.0",
         "react-beautiful-dnd": "^13.1.1",
         "react-dom": "^18.2.0",
+        "react-modal": "^3.16.3",
         "react-router-dom": "^6.22.3"
       },
       "devDependencies": {
@@ -2404,6 +2405,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/exenv": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/exenv/-/exenv-1.2.2.tgz",
+      "integrity": "sha512-Z+ktTxTwv9ILfgKCk32OX3n/doe+OcLTRtqK9pcL+JsP3J1/VW8Uvl4ZjLlKqeW4rzK4oesDOGMEMRIZqtP4Iw==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -3968,6 +3975,28 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
     },
+    "node_modules/react-lifecycles-compat": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
+      "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA==",
+      "license": "MIT"
+    },
+    "node_modules/react-modal": {
+      "version": "3.16.3",
+      "resolved": "https://registry.npmjs.org/react-modal/-/react-modal-3.16.3.tgz",
+      "integrity": "sha512-yCYRJB5YkeQDQlTt17WGAgFJ7jr2QYcWa1SHqZ3PluDmnKJ/7+tVU+E6uKyZ0nODaeEj+xCpK4LcSnKXLMC0Nw==",
+      "license": "MIT",
+      "dependencies": {
+        "exenv": "^1.2.0",
+        "prop-types": "^15.7.2",
+        "react-lifecycles-compat": "^3.0.0",
+        "warning": "^4.0.3"
+      },
+      "peerDependencies": {
+        "react": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19",
+        "react-dom": "^0.14.0 || ^15.0.0 || ^16 || ^17 || ^18 || ^19"
+      }
+    },
     "node_modules/react-redux": {
       "version": "7.2.9",
       "resolved": "https://registry.npmjs.org/react-redux/-/react-redux-7.2.9.tgz",
@@ -4845,6 +4874,15 @@
         "terser": {
           "optional": true
         }
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/which": {

--- a/IslandOpsDirectory/client/package.json
+++ b/IslandOpsDirectory/client/package.json
@@ -14,6 +14,7 @@
     "react": "^18.2.0",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.2.0",
+    "react-modal": "^3.16.3",
     "react-router-dom": "^6.22.3"
   },
   "devDependencies": {

--- a/IslandOpsDirectory/client/src/pages/Dashboard.css
+++ b/IslandOpsDirectory/client/src/pages/Dashboard.css
@@ -135,6 +135,51 @@
   cursor: pointer;
 }
 
+/* all of these buttons have the same color and then a lighter version of the orange as the hover */
+.add-task-btn:hover {
+  background: #ff874f;
+}
+
+.edit-task-btn {
+  background: #E5DCC3;
+  color: #CC5723;
+  font-weight: 600;
+  margin-left: 0.3em;
+}
+.edit-task-btn:hover {
+  background: #ff874f;
+}
+
+.delete-task-btn {
+  background: #CC5723;
+  color: #fff;
+  font-weight: 600;
+  margin-left: 0.3em;
+}
+.delete-task-btn:hover {
+  background: #ff874f;
+}
+
+/* modal button styling */
+.submit-btn {
+  background: #CC5723;
+  color: #fff;
+  font-weight: 600;
+}
+.submit-btn:hover {
+  background: #ff874f;
+}
+
+.cancel-btn {
+  background: #ccc;
+  color: #535353;
+  font-weight: 600;
+  margin-left: 0.5em;
+}
+.cancel-btn:hover {
+  background: #b0b0b0;
+}
+
 .tasks-container {
   display: flex;
   flex-direction: column;
@@ -192,6 +237,40 @@
   gap: 0.5rem;
   flex-wrap: wrap;
   margin-bottom: 1rem;
+}
+
+/* this makes it so when youre in the modal, everything behing it goes a little gray */
+.task-modal-overlay {
+  position: fixed;
+  top: 0; left: 0; right: 0; bottom: 0;
+  background: rgba(0,0,0,0.5); 
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+/* the whole modal box */
+.task-modal {
+  background: #E5DCC3;
+  border-radius: 12px;
+  box-shadow: 0 8px 32px rgba(0,0,0,0.2);
+  max-width: 400px;
+  width: 90%;
+  padding: 2rem;
+  position: relative;
+  z-index: 1001;
+  animation: fadeIn 0.2s;
+}
+
+/* this is just the main heading for the modal */
+.task-modal h2 {
+  color: #333;
+}
+
+/* this is for the text labels like 'description' and 'due date' */
+.task-form {
+  color: #333;
 }
 
 .label {


### PR DESCRIPTION
In order to add 'edit' and 'delete' functionality to tasks in the kanban board, it made more sense to make a basic modal to handle add and edit on submit. Therefore when you edit a task and submit on a button click, it is updated to the database as much as a new task would be sent to the database upon submission. Additionally, on each task card, I added a delete button with a simple 'x' in order to remove it from the backend.

**In Dashboard.jsx:**
- Column component around line 333, addTask onClick function was updated to set the modal open and gather the task details
- Modal around line 432, handles either edit or add task, depending on if you selected a task that existed before or not, then asks for several labels, ie, task title, task description, difficulty and due date, within the modal. The code here also should just handle this information submitting to the database.

**In Dashboard.css**
- overall tried to maintain Isabellas styling as frontend developer (still needs her touch)
- I added add, edit, and delete button styling, all with hover states
- styled buttons in the modal specifically
- styled the modal as well, dimming it on open, setting background colors and form fields with colors used elsewhere

**In Package.json and Package-lock.json**
- I had to import the react-modal, so reviewers, do npm install while in the client folder